### PR TITLE
add comment for usb descriptors, improve blinkrs check

### DIFF
--- a/src/constants.rs
+++ b/src/constants.rs
@@ -1,3 +1,4 @@
+// USB device descriptors taken from https://git.io/JI4nK
 pub const PRODUCT_ID: u16 = 0x01ed;
 pub const VENDOR_ID: u16 = 0x27b8;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,11 +40,10 @@ mod error;
 mod message;
 
 fn is_blinker(device: &Device<Context>) -> bool {
-  if let Ok(desc) = device.device_descriptor() {
-    return desc.num_configurations() > 0 && desc.product_id() == PRODUCT_ID && desc.vendor_id() == VENDOR_ID;
-  }
-
-  false
+  device
+    .device_descriptor()
+    .map(|desc| desc.num_configurations() > 0 && desc.product_id() == PRODUCT_ID && desc.vendor_id() == VENDOR_ID)
+    .unwrap_or(false)
 }
 
 fn send(device: &Device<Context>, message: &Message) -> Result<usize, BlinkError> {


### PR DESCRIPTION
adding usb descriptors link for posterity, improve `is_blinker` organization