### PR TITLE
fix: Bump rusb to comply with sec advisory

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,4 +19,4 @@ name = "blinkrs"
 path = "src/bin/main.rs"
 
 [dependencies]
-rusb = "0.6.5"
+rusb = "0.8.1"


### PR DESCRIPTION
Hello :slightly_smiling_face:. This PR addresses https://rustsec.org/advisories/RUSTSEC-2020-0098. The change is just a version bump. The tests are passing