### PR TITLE
adding optional index to possible messages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,22 +4,22 @@ version = 3
 
 [[package]]
 name = "blinkrs"
-version = "1.0.2"
+version = "2.0.0"
 dependencies = [
  "rusb",
 ]
 
 [[package]]
 name = "cc"
-version = "1.0.69"
+version = "1.0.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e70cc2f62c6ce1868963827bd677764c62d07c3d9a3e1fb1177ee1a9ab199eb2"
+checksum = "22a9137b95ea06864e018375b72adfb7db6e6f68cfc8df5a04d00288050485ee"
 
 [[package]]
 name = "libc"
-version = "0.2.98"
+version = "0.2.112"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "320cfe77175da3a483efed4bc0adc1968ca050b098ce4f2f1c13a56626128790"
+checksum = "1b03d17f364a3a042d5e5d46b053bbbf82c92c9430c592dd4c064dc6ee997125"
 
 [[package]]
 name = "libusb1-sys"
@@ -35,9 +35,9 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.19"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3831453b3449ceb48b6d9c7ad7c96d5ea673e9b470a1dc578c2ce6521230884c"
+checksum = "58893f751c9b0412871a09abd62ecd2a00298c6c83befa223ef98c52aef40cbe"
 
 [[package]]
 name = "rusb"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -23,9 +23,9 @@ checksum = "1b03d17f364a3a042d5e5d46b053bbbf82c92c9430c592dd4c064dc6ee997125"
 
 [[package]]
 name = "libusb1-sys"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e22e89d08bbe6816c6c5d446203b859eba35b8fa94bf1b7edb2f6d25d43f023f"
+checksum = "b8772b7e8d4d988e19684aec5a3f5e470ecaf5c705cf0303da3973508e873027"
 dependencies = [
  "cc",
  "libc",
@@ -41,9 +41,9 @@ checksum = "58893f751c9b0412871a09abd62ecd2a00298c6c83befa223ef98c52aef40cbe"
 
 [[package]]
 name = "rusb"
-version = "0.8.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9a5084628cc5be77b1c750b3e5ee0cc519d2f2491b3f06b78b3aac3328b00ad"
+checksum = "83b454219aa5007af92a042ec13b2035325318a21d3c6be18bf592f841430794"
 dependencies = [
  "libc",
  "libusb1-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blinkrs"
-version = "1.0.2"
+version = "2.0.0"
 authors = ["Danny Hadley <dadleyy@gmail.com>"]
 edition = "2018"
 description = "A small api for interacting with blink(1) LED lights."

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,4 +19,4 @@ name = "blinkrs"
 path = "src/bin/main.rs"
 
 [dependencies]
-rusb = "0.8.1"
+rusb = "^0.9"

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -28,6 +28,18 @@ where
   let bits = input.as_ref().split(" ").collect::<Vec<&str>>();
 
   match bits[..] {
+    ["i", i, f, r, g, b] => {
+      let index = i.parse::<u8>();
+      let fade = f.parse::<u64>();
+      let red = r.parse::<u8>();
+      let green = g.parse::<u8>();
+      let blue = b.parse::<u8>();
+      let color = zip(zip(red, green), blue).map(|((r, g), b)| Color::Three(r, g, b));
+      let message = zip(zip(fade, index), color)
+        .map(|((fade, index), color)| Message::Fade(color, Duration::from_millis(fade), Some(index)));
+      message.ok()
+    }
+
     ["i", i, r, g, b] => {
       let index = i.parse::<u8>();
       let red = r.parse::<u8>();

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -6,5 +6,6 @@ pub const VENDOR_ID: u16 = 0x27b8;
 pub const HID_SET_REPORT: u8 = 0x09;
 pub const HID_FEATURE: u16 = 0x03 << 0x08;
 
-pub const FADE_COMMAND_ACTION: u8 = 0x63;
-pub const IMMEDIATE_COMMAND_ACTION: u8 = 0x6e;
+// Full command list can be found at github.com/todbot/blink1/blob/9bec7d35/hardware/firmware_mk2/main.c#L477-L490.
+pub const FADE_COMMAND_ACTION: u8 = 0x63; // 'c'
+pub const IMMEDIATE_COMMAND_ACTION: u8 = 0x6e; // 'n'

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,7 +72,6 @@ fn send(device: &Device<Context>, message: &Message) -> Result<usize, BlinkError
   }
 
   let buffer = message.buffer();
-  println!("[debug] sending buffer {:?}", buffer);
   let time = Duration::new(0, 100);
   let r_type = request_type(Direction::Out, RequestType::Class, Recipient::Interface);
   let request_value: u16 = HID_FEATURE | (buffer[0] as u16);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,6 +72,7 @@ fn send(device: &Device<Context>, message: &Message) -> Result<usize, BlinkError
   }
 
   let buffer = message.buffer();
+  println!("[debug] sending buffer {:?}", buffer);
   let time = Duration::new(0, 100);
   let r_type = request_type(Direction::Out, RequestType::Class, Recipient::Interface);
   let request_value: u16 = HID_FEATURE | (buffer[0] as u16);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,7 +23,21 @@
 //! }
 //! ```
 //!
+//! #### Extending The blink(1) Device
+//!
+//! The blink(1) device supports the control of additional lights by using three connections (ground, power, and data)
+//! exposed under the "diffuser" cap of the enclosure. A tutorial for adding a Neopixel strip can be found in [this
+//! blog post][b].
+//!
+//! To accomodate these setups, the `Message` kind carries an optional "index" -
+//!
+//! ```rust
+//! use blinkrs::{Message,Color};
+//! Message::Immediate(Color::from("red"), Some(10));
+//! ```
+//!
 //! [blink(1)]: https://blink1.thingm.com
+//! [b]: https://thingm.com/blog/2017/12/using-the-blink1-mk2-led-strip-adapter
 
 use rusb::{request_type, Context, Device, DeviceHandle, Direction, Recipient, RequestType, UsbContext};
 use std::fmt;

--- a/src/message.rs
+++ b/src/message.rs
@@ -30,10 +30,14 @@ impl Message {
         let tl = dms.checked_rem(0xff).unwrap_or(0) as u8;
         [0x01, FADE_COMMAND_ACTION, r, g, b, th, tl, index.unwrap_or(0x00)]
       }
-      Message::Immediate(color, index) => {
+      // NOTE: immediate sets with index is not supported, recommended workaround:
+      // https://github.com/todbot/blink1/issues/251
+      Message::Immediate(color, Some(index)) => {
+        Message::Fade(color.clone(), Duration::from_millis(0), Some(*index)).buffer()
+      }
+      Message::Immediate(color, None) => {
         let (r, g, b) = color.rgb();
-        let i = index.unwrap_or(0);
-        [0x01, IMMEDIATE_COMMAND_ACTION, r, g, b, 0x00, 0x00, i]
+        [0x01, IMMEDIATE_COMMAND_ACTION, r, g, b, 0x00, 0x00, 0]
       }
     }
   }


### PR DESCRIPTION
the blink(1) device can actually control more than the to ws281 pixels on the board itself by using the three PWR, GND + DAT connections available. These can be seen in this [blog post](https://thingm.com/blog/2017/12/using-the-blink1-mk2-led-strip-adapter).

I believe this to be a breaking change since this enum is a public interface so I'm bumping to v2.0.0